### PR TITLE
Refactor to match GP as a plugin:

### DIFF
--- a/gp-views.php
+++ b/gp-views.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Plugin name: GlotPress: Views
+ * Plugin author: Automattic
+ * Version: 1.0
+ *
+ * Description: GlotPress plugin to set up predefined views to search for strings using multiple conditions
+ */
 
 require_once( dirname(__FILE__) .'/includes/router.php' );
 require_once( dirname(__FILE__) .'/things/view.php' );
@@ -12,14 +19,26 @@ class GP_Views {
 
 	var $views = array();
 
-	public function init() {
+	public static $instance = null;
+
+	public static function init() {
+		self::get_instance();
+	}
+
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function __construct() {
 		add_action( 'gp_translation_set_filters', array( $this, 'translation_set_filters' ) );
 		add_filter( 'gp_for_translation_where', array( $this, 'for_translation_where' ), 10, 2 );
 		add_filter( 'gp_project_actions', array( $this, 'gp_project_actions' ), 10, 2 );
 		$this->add_routes();
 	}
-
-
 
 	function set_project_id( $project_id ) {
 		$this->project_id = $project_id;
@@ -204,6 +223,4 @@ class GP_Views {
 		}
 }
 
-$gp_plugin_views = new GP_Views;
-add_action( 'gp_init', array( $gp_plugin_views, 'init' ) );
-
+add_action( 'gp_init', array( 'GP_Views', 'init' ) );

--- a/gp-views.php
+++ b/gp-views.php
@@ -19,7 +19,7 @@ class GP_Views {
 
 	var $views = array();
 
-	public static $instance = null;
+	private static $instance = null;
 
 	public static function init() {
 		self::get_instance();

--- a/includes/router.php
+++ b/includes/router.php
@@ -2,6 +2,9 @@
 class GP_Route_Views extends GP_Route_Main {
 
 	function __construct() {
+		global $gp_plugin_views;
+
+		$this->plugin = $gp_plugin_views;
 		$this->template_path = dirname( dirname( __FILE__ ) ) . '/templates/';
 	}
 
@@ -16,8 +19,9 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
-		$views = GP::$plugins->views->views;
+		$this->plugin->set_project_id( $project->id );
+		
+		$views = $this->plugin->views;
 
 		$this->tmpl( 'views', get_defined_vars() );
 
@@ -34,7 +38,7 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
 		$view = new GP_Views_View( array() );
 		$this->tmpl( 'edit', get_defined_vars() );
@@ -51,13 +55,13 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
-		if ( ! isset( GP::$plugins->views->views[$view_id] ) ) {
+		if ( ! isset( $this->plugin->views[$view_id] ) ) {
 			$this->die_with_404();
 		}
 
-		GP::$plugins->views->delete( $view_id );
+		$this->plugin->delete( $view_id );
 		$this->notices[] =  __( 'View deleted' );
 
 		$this->redirect( gp_url( '/views' . gp_url_project( $project) ) );
@@ -74,9 +78,9 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
-		if ( ! GP::$plugins->views->save( gp_post('view') ) ) {
+		if ( ! $this->plugin->save( gp_post('view') ) ) {
 			$this->errors[] = __( 'Error creating view' );
 		} else {
 			$this->notices[] =  __( 'View Created' );
@@ -95,13 +99,13 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
-		if ( ! isset( GP::$plugins->views->views[$view_id] ) ) {
+		if ( ! isset( $this->plugin->views[$view_id] ) ) {
 			$this->die_with_404();
 		}
 
-		$view = GP::$plugins->views->views[$view_id];
+		$view = $this->plugin->views[$view_id];
 		$this->tmpl( 'edit', get_defined_vars() );
 	}
 
@@ -116,13 +120,13 @@ class GP_Route_Views extends GP_Route_Main {
 			return;
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
-		if ( ! isset( GP::$plugins->views->views[$view_id] ) ) {
+		if ( ! isset( $this->plugin->views[$view_id] ) ) {
 			$this->die_with_404();
 		}
 
-		if ( ! GP::$plugins->views->save( gp_post('view'), $view_id ) ) {
+		if ( ! $this->plugin->save( gp_post('view'), $view_id ) ) {
 			$this->errors[] = __( 'Error creating view' );
 		} else {
 			$this->notices[] =  __( 'View saved' );
@@ -143,9 +147,9 @@ class GP_Route_Views extends GP_Route_Main {
 			$this->die_with_404();
 		}
 
-		GP::$plugins->views->set_project_id( $project->id );
+		$this->plugin->set_project_id( $project->id );
 
-		if ( ! isset( GP::$plugins->views->views[$id] ) ) {
+		if ( ! isset( $this->plugin->views[$id] ) ) {
 			$this->die_with_404();
 		}
 
@@ -155,14 +159,14 @@ class GP_Route_Views extends GP_Route_Main {
 
 		if ( false === $stats ) {
 			$sets = GP::$translation_set->by_project_id( $project->id );
-			GP::$plugins->views->current_view = $id;
+			$this->plugin->current_view = $id;
 
 			$stats = array();
-			GP::$plugins->views->set_originals_ids_for_view();
-			$stats['originals'] = count( GP::$plugins->views->originals_ids  );
+			$this->plugin->set_originals_ids_for_view();
+			$stats['originals'] = count( $this->plugin->originals_ids  );
 
 			foreach ( $sets as $set ) {
-				$translated_count = GP::$plugins->views->translations_count_in_view_for_set_id( $set->id );
+				$translated_count = $this->plugin->translations_count_in_view_for_set_id( $set->id );
 				$stats['translation_sets'][$set->locale]['current'] = $translated_count;
 				$stats['translation_sets'][$set->locale]['untranslated'] = $stats['originals'] - $translated_count;
 				$stats['translation_sets'][$set->locale]['percent'] = floor( $translated_count/$stats['originals']*100 );

--- a/includes/router.php
+++ b/includes/router.php
@@ -2,9 +2,7 @@
 class GP_Route_Views extends GP_Route_Main {
 
 	function __construct() {
-		global $gp_plugin_views;
-
-		$this->plugin = $gp_plugin_views;
+		$this->plugin = GP_Views::get_instance();
 		$this->template_path = dirname( dirname( __FILE__ ) ) . '/templates/';
 	}
 
@@ -20,7 +18,7 @@ class GP_Route_Views extends GP_Route_Main {
 		}
 
 		$this->plugin->set_project_id( $project->id );
-		
+
 		$views = $this->plugin->views;
 
 		$this->tmpl( 'views', get_defined_vars() );


### PR DESCRIPTION
- Remove inheritance of non-existant GP_Plugin
- Use regular WP `add_filter|action` calls
- Add `gp_` prefix to filters/actions
- Replace usages of non existant GP_User class with either wp user functions or `GP::$permission` calls
- Use regular wp_option calls (existing filters will need to be saved again)
- Misc compat fixes
